### PR TITLE
More space for IPv6 Peer names / Duration

### DIFF
--- a/show-bgp-neat.slax
+++ b/show-bgp-neat.slax
@@ -17,16 +17,17 @@ import "../import/junos.xsl";
 
 match / {
     <op-script-results> {
+        var $output-format = "%-35s%-10s%-13s%-12s%-10s%-10s%-10s%-5s";
+        <output> jcs:printf($output-format, "Peer", "AS", "State", "Duration", "Active", "Recevied", "Accepted", "Description");
 
         /* Get a list of all security policies */
         var $show-bgp-summary = {
             <command> "show bgp summary";
         }
         var $neighbour-list = jcs:invoke( $show-bgp-summary );
-        <output> jcs:printf("%-20s%-15s%-12s%-10s%-10s%-10s%-10s%-5s", "Peer", "AS", "State", "Duration", "Active", "Recevied", "Accepted", "Description");
         /* Loop through the results looking for count parameters */
         for-each ($neighbour-list/bgp-peer) {
-            <output> jcs:printf("%-20s%-15s%-12s%-10s%-10s%-10s%-10s%-5s",
+            <output> jcs:printf($output-format,
                 peer-address,
                 peer-as,
                 peer-state,


### PR DESCRIPTION
Same as the last PR, with all of the upstream changes added in (and no dos2unix conversion).  Tested on MX platform version 12.3R6.6.
